### PR TITLE
Mark optional interfaces, remove generated example peers section.

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,8 +15,7 @@ provides:
 requires:
   mysql:
     interface: mysql
+    optional: true
   redis:
     interface: redis
-peers:
-  peer-relation:
-    interface: interface-name
+    optional: true


### PR DESCRIPTION
Noticed that the database interfaces were not declared as optional.
